### PR TITLE
Add missing exports to JavaScript.Web.Storage

### DIFF
--- a/src/JavaScript/Web/Storage.hs
+++ b/src/JavaScript/Web/Storage.hs
@@ -7,9 +7,23 @@ data Storage
 localStorage :: Storage
 localStorage = undefined
 
+sessionStorage :: Storage
+sessionStorage = undefined
+
+getLength :: Storage -> IO Int
+getLength = undefined
+
+getIndex :: Int -> Storage -> IO (Maybe JSString)
+getIndex = undefined
+
 getItem :: JSString -> Storage -> IO (Maybe JSString)
 getItem = undefined
 
 setItem :: JSString -> JSString -> Storage -> IO ()
 setItem = undefined
 
+removeItem :: JSString -> Storage -> IO ()
+removeItem = undefined
+
+clear :: Storage -> IO ()
+clear = undefined


### PR DESCRIPTION
https://github.com/ghcjs/ghcjs-base/blob/968dff527c2be2d3d4815e437ad9b2931ea1f35d/JavaScript/Web/Storage.hs

At the time of this PR this is the the most recent commit of ghcjs-base/master.